### PR TITLE
fix: cron in debian runs with new syntax

### DIFF
--- a/zarf/cron_monthly.sh
+++ b/zarf/cron_monthly.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/sh
 set -e
-goback -d /etc/goback/backupd.monthly/ > /dev/null
+goback backup /etc/goback/backupd.monthly/ > /dev/null

--- a/zarf/cron_weekly.sh
+++ b/zarf/cron_weekly.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/sh
 set -e
-goback -d /etc/goback/backupd.weekly/ > /dev/null
+goback backup /etc/goback/backupd.weekly/ > /dev/null


### PR DESCRIPTION
fix issue where the cron script added to the debian package would still use parameter -p instead of subcomamnd "backup"
+ add some log entries